### PR TITLE
Add support for 0.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.0.0
+- Fix support for R.E.P.O. v0.3.x
+  - Add support for `DeathHeadBattery` and `TumbleClimb` upgrades
+- Updated REPOLib minimum version to 3.0.3
+
 # 2.2.6
 - Fixed small bug
 

--- a/Core/PunManagerWrapper.cs
+++ b/Core/PunManagerWrapper.cs
@@ -31,7 +31,10 @@ public class PunManagerWrapper(PunManager manager)
     
     public int UpgradePlayerTumbleLaunch(string steamId)
         => manager.UpgradePlayerTumbleLaunch(steamId);
-    
+
+    public int UpgradePlayerTumbleClimb(string steamId)
+        => manager.UpgradePlayerTumbleClimb(steamId);
+
     public int UpgradeMapPlayerCount(string steamId)
         => manager.UpgradeMapPlayerCount(steamId);
     
@@ -46,4 +49,7 @@ public class PunManagerWrapper(PunManager manager)
     
     public int UpgradePlayerThrowStrength(string steamId)
         => manager.UpgradePlayerThrowStrength(steamId);
+
+    public int UpgradePlayerDeathHeadBattery(string steamId)
+        => manager.UpgradeDeathHeadBattery(steamId);
 }

--- a/Core/SyncManager.cs
+++ b/Core/SyncManager.cs
@@ -12,17 +12,19 @@ public static class SyncManager
 {
     private const string Section = "Default Upgrades";
     private const string ModdedSection = "Modded Upgrades";
-    private static ConfigEntry<bool> _syncHealth         = Entry.BepConfig.Bind(Section, "Health", true, "Sync Max Health");
-    private static ConfigEntry<bool> _syncStamina        = Entry.BepConfig.Bind(Section, "Stamina", true, "Sync Max Stamina");
-    private static ConfigEntry<bool> _syncExtraJump      = Entry.BepConfig.Bind(Section, "Extra Jump", true, "Sync Extra Jump");
-    private static ConfigEntry<bool> _syncMapPlayerCount = Entry.BepConfig.Bind(Section, "Map Player Count", true, "Sync Map Player Count");
-    private static ConfigEntry<bool> _syncGrabRange      = Entry.BepConfig.Bind(Section, "Grab Range", true, "Sync Grab Range");
-    private static ConfigEntry<bool> _syncGrabStrength   = Entry.BepConfig.Bind(Section, "Grab Strength", true, "Sync Grab Strength");
-    private static ConfigEntry<bool> _syncThrowStrength  = Entry.BepConfig.Bind(Section, "Throw Strength", true, "Sync Throw Strength");
-    private static ConfigEntry<bool> _syncSprintSpeed    = Entry.BepConfig.Bind(Section, "Sprint Speed", true, "Sync Sprint Speed");
-    private static ConfigEntry<bool> _syncTumbleLaunch   = Entry.BepConfig.Bind(Section, "Tumble Launch", true, "Sync Tumble Launch");
-    private static ConfigEntry<bool> _syncTumbleWings    = Entry.BepConfig.Bind(Section, "Tumble Wings", true, "Sync Tumble Wings");
-    private static ConfigEntry<bool> _syncCrouchRest     = Entry.BepConfig.Bind(Section, "Crouch Rest", true, "Sync Crouch Rest");
+    private static ConfigEntry<bool> _syncHealth           = Entry.BepConfig.Bind(Section, "Health", true, "Sync Max Health");
+    private static ConfigEntry<bool> _syncStamina          = Entry.BepConfig.Bind(Section, "Stamina", true, "Sync Max Stamina");
+    private static ConfigEntry<bool> _syncExtraJump        = Entry.BepConfig.Bind(Section, "Extra Jump", true, "Sync Extra Jump");
+    private static ConfigEntry<bool> _syncMapPlayerCount   = Entry.BepConfig.Bind(Section, "Map Player Count", true, "Sync Map Player Count");
+    private static ConfigEntry<bool> _syncGrabRange        = Entry.BepConfig.Bind(Section, "Grab Range", true, "Sync Grab Range");
+    private static ConfigEntry<bool> _syncGrabStrength     = Entry.BepConfig.Bind(Section, "Grab Strength", true, "Sync Grab Strength");
+    private static ConfigEntry<bool> _syncThrowStrength    = Entry.BepConfig.Bind(Section, "Throw Strength", true, "Sync Throw Strength");
+    private static ConfigEntry<bool> _syncSprintSpeed      = Entry.BepConfig.Bind(Section, "Sprint Speed", true, "Sync Sprint Speed");
+    private static ConfigEntry<bool> _syncTumbleLaunch     = Entry.BepConfig.Bind(Section, "Tumble Launch", true, "Sync Tumble Launch");
+    private static ConfigEntry<bool> _syncTumbleWings      = Entry.BepConfig.Bind(Section, "Tumble Wings", true, "Sync Tumble Wings");
+    private static ConfigEntry<bool> _syncTumbleClimb      = Entry.BepConfig.Bind(Section, "Tumble Climb", true, "Sync Tumble Climb");
+    private static ConfigEntry<bool> _syncCrouchRest       = Entry.BepConfig.Bind(Section, "Crouch Rest", true, "Sync Crouch Rest");
+    private static ConfigEntry<bool> _syncDeathHeadBattery = Entry.BepConfig.Bind(Section, "Death Head Battery", true, "Sync Dead Head Battery");
     internal static ConcurrentDictionary<UpgradeId, ConfigEntry<bool>> registeredModdedUpgrades = [];
 
     internal static void Init()
@@ -234,7 +236,9 @@ public static class SyncManager
         UpgradeType.GrabRange => _syncGrabRange.Value,
         UpgradeType.ThrowStrength => _syncThrowStrength.Value,
         UpgradeType.TumbleWings => _syncTumbleWings.Value,
+        UpgradeType.TumbleClimb => _syncTumbleClimb.Value,
         UpgradeType.CrouchRest => _syncCrouchRest.Value,
+        UpgradeType.DeathHeadBattery => _syncDeathHeadBattery.Value,
         UpgradeType.Modded => registeredModdedUpgrades.TryGetValue(key, out ConfigEntry<bool> value) && value.Value,
         var _ => false
     };

--- a/Core/SyncUtil.cs
+++ b/Core/SyncUtil.cs
@@ -17,18 +17,20 @@ public static class SyncUtil
     private const string PlayerUpgrade = "playerUpgrade";
     private const string AppliedPlayerUpgrade = "appliedPlayerUpgrade";
     
-    public static readonly UpgradeId HealthId         = new(UpgradeType.Health);
-    public static readonly UpgradeId StaminaId        = new(UpgradeType.Stamina);
-    public static readonly UpgradeId ExtraJumpId      = new(UpgradeType.ExtraJump);
-    public static readonly UpgradeId TumbleLaunchId   = new(UpgradeType.TumbleLaunch);
-    public static readonly UpgradeId MapPlayerCountId = new(UpgradeType.MapPlayerCount);
-    public static readonly UpgradeId SprintSpeedId    = new(UpgradeType.SprintSpeed);
-    public static readonly UpgradeId GrabStrengthId   = new(UpgradeType.GrabStrength);
-    public static readonly UpgradeId GrabRangeId      = new(UpgradeType.GrabRange);
-    public static readonly UpgradeId ThrowStrengthId  = new(UpgradeType.ThrowStrength);
-    public static readonly UpgradeId TumbleWingsId    = new(UpgradeType.TumbleWings);
-    public static readonly UpgradeId CrouchRestId     = new(UpgradeType.CrouchRest);
-    
+    public static readonly UpgradeId HealthId          = new(UpgradeType.Health);
+    public static readonly UpgradeId StaminaId         = new(UpgradeType.Stamina);
+    public static readonly UpgradeId ExtraJumpId       = new(UpgradeType.ExtraJump);
+    public static readonly UpgradeId TumbleLaunchId    = new(UpgradeType.TumbleLaunch);
+    public static readonly UpgradeId MapPlayerCountId  = new(UpgradeType.MapPlayerCount);
+    public static readonly UpgradeId SprintSpeedId     = new(UpgradeType.SprintSpeed);
+    public static readonly UpgradeId GrabStrengthId    = new(UpgradeType.GrabStrength);
+    public static readonly UpgradeId GrabRangeId       = new(UpgradeType.GrabRange);
+    public static readonly UpgradeId ThrowStrengthId   = new(UpgradeType.ThrowStrength);
+    public static readonly UpgradeId TumbleClimbId     = new(UpgradeType.TumbleClimb);
+    public static readonly UpgradeId TumbleWingsId     = new(UpgradeType.TumbleWings);
+    public static readonly UpgradeId CrouchRestId      = new(UpgradeType.CrouchRest);
+    public static readonly UpgradeId DeathHeadBatteryId = new(UpgradeType.DeathHeadBattery);
+
     private static readonly ConcurrentQueue<ISyncRequest> SyncQueue = [];
     
     /// <summary>
@@ -99,8 +101,10 @@ public static class SyncUtil
         "Strength" => UpgradeType.GrabStrength,
         "Range" => UpgradeType.GrabRange,
         "Throw" => UpgradeType.ThrowStrength,
+        "Climb" => UpgradeType.TumbleClimb,
         "TumbleWings" => UpgradeType.TumbleWings,
         "CrouchRest" => UpgradeType.CrouchRest,
+        "DeathHead" => UpgradeType.DeathHeadBattery,
         // Assume
         _ => UpgradeType.Modded
     };
@@ -122,8 +126,10 @@ public static class SyncUtil
         UpgradeType.GrabStrength => "Strength",
         UpgradeType.GrabRange => "Range",
         UpgradeType.ThrowStrength => "Throw",
+        UpgradeType.TumbleClimb => "Climb",
         UpgradeType.TumbleWings => "TumbleWings",
         UpgradeType.CrouchRest => "CrouchRest",
+        UpgradeType.DeathHeadBattery => "DeathHead",
         UpgradeType.Modded => "Modded: Unknown",
         _ => throw new ArgumentException($"Invalid UpgradeType for {nameof(GetUpgradeName)}")
     };
@@ -146,8 +152,10 @@ public static class SyncUtil
         UpgradeType.GrabStrength => stats.playerUpgradeStrength,
         UpgradeType.GrabRange => stats.playerUpgradeRange,
         UpgradeType.ThrowStrength => stats.playerUpgradeThrow,
+        UpgradeType.TumbleClimb => stats.playerUpgradeTumbleClimb,
         UpgradeType.TumbleWings => stats.playerUpgradeTumbleWings,
         UpgradeType.CrouchRest => stats.playerUpgradeCrouchRest,
+        UpgradeType.DeathHeadBattery => stats.playerUpgradeDeathHeadBattery,
         UpgradeType.Modded => stats.dictionaryOfDictionaries[id.RawName],
         _ => throw new ArgumentException($"Invalid UpgradeType for {nameof(GetUpgrades)}")
     };
@@ -229,7 +237,9 @@ public static class SyncUtil
         UpgradeType.GrabRange => bundle.Manager.UpgradePlayerGrabRange(steamId),
         UpgradeType.ThrowStrength => bundle.Manager.UpgradePlayerThrowStrength(steamId),
         UpgradeType.TumbleWings => bundle.Manager.UpgradePlayerTumbleWings(steamId),
+        UpgradeType.TumbleClimb => bundle.Manager.UpgradePlayerTumbleClimb(steamId),
         UpgradeType.CrouchRest => bundle.Manager.UpgradePlayerCrouchRest(steamId),
+        UpgradeType.DeathHeadBattery => bundle.Manager.UpgradePlayerDeathHeadBattery(steamId),
         UpgradeType.Modded => UpgradeModded(bundle, SemiFunc.PlayerAvatarGetFromSteamID(steamId), key, 1),
         _ => throw new ArgumentException($"Invalid UpgradeType for {nameof(CallUpdateFunction)}")
     };

--- a/Core/SyncUtil.cs
+++ b/Core/SyncUtil.cs
@@ -17,18 +17,18 @@ public static class SyncUtil
     private const string PlayerUpgrade = "playerUpgrade";
     private const string AppliedPlayerUpgrade = "appliedPlayerUpgrade";
     
-    public static readonly UpgradeId HealthId          = new(UpgradeType.Health);
-    public static readonly UpgradeId StaminaId         = new(UpgradeType.Stamina);
-    public static readonly UpgradeId ExtraJumpId       = new(UpgradeType.ExtraJump);
-    public static readonly UpgradeId TumbleLaunchId    = new(UpgradeType.TumbleLaunch);
-    public static readonly UpgradeId MapPlayerCountId  = new(UpgradeType.MapPlayerCount);
-    public static readonly UpgradeId SprintSpeedId     = new(UpgradeType.SprintSpeed);
-    public static readonly UpgradeId GrabStrengthId    = new(UpgradeType.GrabStrength);
-    public static readonly UpgradeId GrabRangeId       = new(UpgradeType.GrabRange);
-    public static readonly UpgradeId ThrowStrengthId   = new(UpgradeType.ThrowStrength);
-    public static readonly UpgradeId TumbleClimbId     = new(UpgradeType.TumbleClimb);
-    public static readonly UpgradeId TumbleWingsId     = new(UpgradeType.TumbleWings);
-    public static readonly UpgradeId CrouchRestId      = new(UpgradeType.CrouchRest);
+    public static readonly UpgradeId HealthId           = new(UpgradeType.Health);
+    public static readonly UpgradeId StaminaId          = new(UpgradeType.Stamina);
+    public static readonly UpgradeId ExtraJumpId        = new(UpgradeType.ExtraJump);
+    public static readonly UpgradeId TumbleLaunchId     = new(UpgradeType.TumbleLaunch);
+    public static readonly UpgradeId MapPlayerCountId   = new(UpgradeType.MapPlayerCount);
+    public static readonly UpgradeId SprintSpeedId      = new(UpgradeType.SprintSpeed);
+    public static readonly UpgradeId GrabStrengthId     = new(UpgradeType.GrabStrength);
+    public static readonly UpgradeId GrabRangeId        = new(UpgradeType.GrabRange);
+    public static readonly UpgradeId ThrowStrengthId    = new(UpgradeType.ThrowStrength);
+    public static readonly UpgradeId TumbleClimbId      = new(UpgradeType.TumbleClimb);
+    public static readonly UpgradeId TumbleWingsId      = new(UpgradeType.TumbleWings);
+    public static readonly UpgradeId CrouchRestId       = new(UpgradeType.CrouchRest);
     public static readonly UpgradeId DeathHeadBatteryId = new(UpgradeType.DeathHeadBattery);
 
     private static readonly ConcurrentQueue<ISyncRequest> SyncQueue = [];

--- a/Core/UpgradeType.cs
+++ b/Core/UpgradeType.cs
@@ -13,6 +13,7 @@ public enum UpgradeType
     Stamina,
     ExtraJump,
     TumbleLaunch,
+    TumbleClimb,
     MapPlayerCount,
     SprintSpeed,
     GrabStrength,
@@ -20,4 +21,5 @@ public enum UpgradeType
     ThrowStrength,
     TumbleWings,
     CrouchRest,
+    DeathHeadBattery,
 }

--- a/Entry.cs
+++ b/Entry.cs
@@ -9,11 +9,11 @@ using UnityEngine;
 namespace SyncUpgrades;
 
 [BepInPlugin(PluginId, PluginName, PluginVersion)]
-[BepInDependency("REPOLib", "2.1.0")]
+[BepInDependency("REPOLib", "3.0.3")]
 public class Entry : BaseUnityPlugin
 {
     private const string PluginName = "Sync Upgrades";
-    private const string PluginVersion = "2.2.6";
+    private const string PluginVersion = "3.0.0";
     private const string PluginId = "TGO.SyncUpgrades";
 
     private static readonly Harmony Harmony = new(PluginId);

--- a/Patches/PunManagerPatch.cs
+++ b/Patches/PunManagerPatch.cs
@@ -13,95 +13,111 @@ internal class PunManagerPatch
     [HarmonyPrefix]
     [HarmonyWrapSafe]
     [IgnoreMethodPatchException]
-    [HarmonyPatch(nameof(UpdateHealthRightAway), typeof(string))]
-    private static void UpdateHealthRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID)
-        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, SyncUtil.HealthId);
+    [HarmonyPatch(nameof(UpdateHealthRightAway), typeof(string), typeof(int))]
+    private static void UpdateHealthRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID, int value)
+        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, value, SyncUtil.HealthId);
     
     // UpgradePlayerEnergy
     [HarmonyPrefix]
     [HarmonyWrapSafe]
-    [HarmonyPatch(nameof(UpdateEnergyRightAway), typeof(string))]
-    private static void UpdateEnergyRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID)
-        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, SyncUtil.StaminaId);
+    [HarmonyPatch(nameof(UpdateEnergyRightAway), typeof(string), typeof(int))]
+    private static void UpdateEnergyRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID, int value)
+        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, value, SyncUtil.StaminaId);
     
     // UpgradePlayerTumbleLaunch
     [HarmonyPrefix]
     [HarmonyWrapSafe]
-    [HarmonyPatch(nameof(UpdateTumbleLaunchRightAway), typeof(string))]
-    private static void UpdateTumbleLaunchRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID)
-        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, SyncUtil.TumbleLaunchId);
+    [HarmonyPatch(nameof(UpdateTumbleLaunchRightAway), typeof(string), typeof(int))]
+    private static void UpdateTumbleLaunchRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID, int value)
+        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, value, SyncUtil.TumbleLaunchId);
     
     // UpgradePlayerSprintSpeed
     [HarmonyPrefix]
     [HarmonyWrapSafe]
-    [HarmonyPatch(nameof(UpdateSprintSpeedRightAway), typeof(string))]
-    private static void UpdateSprintSpeedRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID)
-        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, SyncUtil.SprintSpeedId);
+    [HarmonyPatch(nameof(UpdateSprintSpeedRightAway), typeof(string), typeof(int))]
+    private static void UpdateSprintSpeedRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID, int value)
+        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, value, SyncUtil.SprintSpeedId);
     
     // UpgradePlayerGrabStrength
     [HarmonyPrefix]
     [HarmonyWrapSafe]
-    [HarmonyPatch(nameof(UpdateGrabStrengthRightAway), typeof(string))]
-    private static void UpdateGrabStrengthRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID)
-        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, SyncUtil.GrabStrengthId);
+    [HarmonyPatch(nameof(UpdateGrabStrengthRightAway), typeof(string), typeof(int))]
+    private static void UpdateGrabStrengthRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID, int value)
+        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, value, SyncUtil.GrabStrengthId);
     
     // UpgradePlayerThrowStrength
     [HarmonyPrefix]
     [HarmonyWrapSafe]
-    [HarmonyPatch(nameof(UpdateThrowStrengthRightAway), typeof(string))]
-    private static void UpdateThrowStrengthRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID)
-        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, SyncUtil.ThrowStrengthId);
+    [HarmonyPatch(nameof(UpdateThrowStrengthRightAway), typeof(string), typeof(int))]
+    private static void UpdateThrowStrengthRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID, int value)
+        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, value, SyncUtil.ThrowStrengthId);
 
     // UpgradePlayerGrabRange
     [HarmonyPrefix]
     [HarmonyWrapSafe]
-    [HarmonyPatch(nameof(UpdateGrabRangeRightAway), typeof(string))]
-    private static void UpdateGrabRangeRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID)
-        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, SyncUtil.GrabRangeId);
+    [HarmonyPatch(nameof(UpdateGrabRangeRightAway), typeof(string), typeof(int))]
+    private static void UpdateGrabRangeRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID, int value)
+        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, value, SyncUtil.GrabRangeId);
     
     // UpgradePlayerExtraJump
     [HarmonyPrefix]
     [HarmonyWrapSafe]
-    [HarmonyPatch(nameof(UpdateExtraJumpRightAway), typeof(string))]
-    private static void UpdateExtraJumpRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID)
-        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, SyncUtil.ExtraJumpId);
+    [HarmonyPatch(nameof(UpdateExtraJumpRightAway), typeof(string), typeof(int))]
+    private static void UpdateExtraJumpRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID, int value)
+        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, value, SyncUtil.ExtraJumpId);
     
     // UpgradeMapPlayerCount
     [HarmonyPrefix]
     [HarmonyWrapSafe]
-    [HarmonyPatch(nameof(UpdateMapPlayerCountRightAway), typeof(string))]
-    private static void UpdateMapPlayerCountRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID)
-        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, SyncUtil.MapPlayerCountId);
+    [HarmonyPatch(nameof(UpdateMapPlayerCountRightAway), typeof(string), typeof(int))]
+    private static void UpdateMapPlayerCountRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID, int value)
+        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, value, SyncUtil.MapPlayerCountId);
     
     // UpgradePlayerTumbleWings
     [HarmonyPrefix]
     [HarmonyWrapSafe]
     [IgnoreMethodPatchException]
-    [HarmonyPatch(nameof(UpdateTumbleWingsRightAway), typeof(string))]
-    private static void UpdateTumbleWingsRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID)
-        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, SyncUtil.TumbleWingsId);
+    [HarmonyPatch(nameof(UpdateTumbleWingsRightAway), typeof(string), typeof(int))]
+    private static void UpdateTumbleWingsRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID, int value)
+        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, value, SyncUtil.TumbleWingsId);
     
     // UpgradeCrouchRest
     [HarmonyPrefix]
     [HarmonyWrapSafe]
     [IgnoreMethodPatchException]
-    [HarmonyPatch(nameof(UpdateCrouchRestRightAway), typeof(string))]
-    private static void UpdateCrouchRestRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID)
-        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, SyncUtil.CrouchRestId);
+    [HarmonyPatch(nameof(UpdateCrouchRestRightAway), typeof(string), typeof(int))]
+    private static void UpdateCrouchRestRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID, int value)
+        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, value, SyncUtil.CrouchRestId);
+
+    // UpgradeTumbleClimb
+    [HarmonyPrefix]
+    [HarmonyWrapSafe]
+    [IgnoreMethodPatchException]
+    [HarmonyPatch(nameof(UpdateTumbleClimbRightAway), typeof(string), typeof(int))]
+    private static void UpdateTumbleClimbRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID, int value)
+        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, value, SyncUtil.TumbleClimbId);
+
+    // UpgradeDeathHeadBattery
+    [HarmonyPrefix]
+    [HarmonyWrapSafe]
+    [IgnoreMethodPatchException]
+    [HarmonyPatch(nameof(UpdateDeathHeadBatteryRightAway), typeof(string), typeof(int))]
+    private static void UpdateDeathHeadBatteryRightAway(PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, string _steamID, int value)
+        => UpgradeWrapper(__instance, ___photonView, ___statsManager, _steamID, value, SyncUtil.TumbleClimbId);
 
     private static void UpgradeWrapper(
         PunManager __instance, PhotonView ___photonView, StatsManager ___statsManager, 
-        string _steamID, UpgradeId upgrade, [CallerMemberName] string methodName = "Unknown Caller Method")
+        string _steamID, int value, UpgradeId upgrade, [CallerMemberName] string methodName = "Unknown Caller Method")
     {
         // If not host OR single-player, return
         if (SemiFunc.IsNotMasterClient())
             return;
         
         #if DEBUG
-        Entry.LogSource.LogInfo($"[{methodName}] Upgrade: " + _steamID);
+        Entry.LogSource.LogInfo($"[{methodName}] Upgrade: " + _steamID + ", Value: " + value);
         #endif
         
         SyncBundle bundle = new(new PunManagerWrapper(__instance), ___photonView, ___statsManager, _steamID);
-        SyncManager.PlayerConsumedUpgrade(bundle, upgrade);
+        SyncManager.PlayerConsumedUpgrade(bundle, upgrade, value);
     }
 }

--- a/SyncUpgrades.csproj
+++ b/SyncUpgrades.csproj
@@ -10,14 +10,6 @@
         <Version>3.0.0</Version>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <RestoreAdditionalProjectSources>
-      https://api.nuget.org/v3/index.json;
-      https://nuget.bepinex.dev/v3/index.json;
-      https://nuget.windows10ce.com/nuget/v3/index.json
-    </RestoreAdditionalProjectSources>
-  </PropertyGroup>
-
   <ItemGroup>
       <Reference Include="Assembly-CSharp">
         <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Assembly-CSharp.dll</HintPath>
@@ -371,6 +363,5 @@
 
     <ItemGroup>
         <PackageReference Include="BepInEx.Core" Version="5.4.21" />
-		<PackageReference Include="Linkoid.Repo.Plugin.Build" Version="*" PrivateAssets="all" />
     </ItemGroup>
 </Project>

--- a/SyncUpgrades.csproj
+++ b/SyncUpgrades.csproj
@@ -8,9 +8,8 @@
         <Configurations>Debug;Release;</Configurations>
         <Platforms>AnyCPU</Platforms>
         <Version>3.0.0</Version>
-		<EnableGameReferences>true</EnableGameReferences>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <RestoreAdditionalProjectSources>
       https://api.nuget.org/v3/index.json;
@@ -21,355 +20,352 @@
 
   <ItemGroup>
       <Reference Include="Assembly-CSharp">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Assembly-CSharp.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>false</Private></Reference>
-      <Reference Include="Assembly-CSharp-firstpass">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
-      </Reference>
       <Reference Include="Autodesk.Fbx">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Autodesk.Fbx.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Autodesk.Fbx.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Facepunch.Steamworks.Win64">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Facepunch.Steamworks.Win64.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Facepunch.Steamworks.Win64.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="FbxBuildTestAssets">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\FbxBuildTestAssets.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\FbxBuildTestAssets.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="mscorlib">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\mscorlib.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\mscorlib.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Newtonsoft.Json">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Newtonsoft.Json.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Newtonsoft.Json.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Photon3Unity3D">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Photon3Unity3D.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Photon3Unity3D.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="PhotonChat">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\PhotonChat.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\PhotonChat.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="PhotonRealtime">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\PhotonRealtime.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\PhotonRealtime.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="PhotonUnityNetworking">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\PhotonUnityNetworking.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\PhotonUnityNetworking.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="PhotonUnityNetworking.Utilities">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\PhotonUnityNetworking.Utilities.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\PhotonUnityNetworking.Utilities.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="PhotonVoice">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\PhotonVoice.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\PhotonVoice.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="PhotonVoice.API">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\PhotonVoice.API.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\PhotonVoice.API.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="PhotonVoice.PUN">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\PhotonVoice.PUN.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\PhotonVoice.PUN.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="REPOLib">
-        <HintPath>..\..\..\AppData\Roaming\r2modmanPlus-local\REPO\profiles\Dev\BepInEx\plugins\Zehs-REPOLib\REPOLib.dll</HintPath>
+        <HintPath>..\..\..\.config\r2modmanPlus-local\REPO\profiles\Default\BepInEx\plugins\Zehs-REPOLib\REPOLib.dll</HintPath>
       </Reference>
       <Reference Include="Sirenix.OdinInspector.Attributes">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Sirenix.OdinInspector.Attributes.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Sirenix.OdinInspector.Attributes.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Sirenix.Serialization">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Sirenix.Serialization.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Sirenix.Serialization.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Sirenix.Serialization.Config">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Sirenix.Serialization.Config.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Sirenix.Serialization.Config.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Sirenix.Utilities">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Sirenix.Utilities.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Sirenix.Utilities.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.ComponentModel.Composition">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.ComponentModel.Composition.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.ComponentModel.Composition.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Core">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Core.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Core.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Data">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Data.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Data.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Drawing">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Drawing.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Drawing.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.IO.Compression">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.IO.Compression.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.IO.Compression.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.IO.Compression.FileSystem">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.IO.Compression.FileSystem.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.IO.Compression.FileSystem.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Net.Http">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Net.Http.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Net.Http.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Numerics">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Numerics.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Numerics.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Runtime.Serialization">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Runtime.Serialization.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Runtime.Serialization.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Transactions">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Transactions.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Transactions.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Xml">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Xml.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Xml.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Xml.Linq">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Xml.Linq.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Xml.Linq.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.AI.Navigation">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.AI.Navigation.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.AI.Navigation.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.Formats.Fbx.Runtime">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.Formats.Fbx.Runtime.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.Formats.Fbx.Runtime.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.InputSystem">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.InputSystem.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.InputSystem.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.InputSystem.ForUI">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.InputSystem.ForUI.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.InputSystem.ForUI.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.Postprocessing.Runtime">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.Postprocessing.Runtime.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.Postprocessing.Runtime.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.RenderPipelines.Core.Runtime">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.RenderPipelines.Core.Runtime.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.RenderPipelines.Core.Runtime.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.RenderPipelines.Core.ShaderLibrary">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.RenderPipelines.Core.ShaderLibrary.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.RenderPipelines.Core.ShaderLibrary.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.RenderPipelines.ShaderGraph.ShaderGraphLibrary">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.RenderPipelines.ShaderGraph.ShaderGraphLibrary.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.RenderPipelines.ShaderGraph.ShaderGraphLibrary.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.TextMeshPro">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.TextMeshPro.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.Timeline">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.Timeline.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.Timeline.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.VisualScripting.Antlr3.Runtime">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.Antlr3.Runtime.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.Antlr3.Runtime.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.VisualScripting.Core">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.Core.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.Core.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.VisualScripting.Flow">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.Flow.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.Flow.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.VisualScripting.State">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.State.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.State.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.AccessibilityModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AccessibilityModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AccessibilityModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.AIModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AIModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AIModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.AndroidJNIModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AndroidJNIModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AndroidJNIModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.AnimationModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ARModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ARModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ARModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.AssetBundleModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.AudioModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ClothModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ClothModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ClothModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ClusterInputModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ClusterInputModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ClusterInputModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ClusterRendererModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ClusterRendererModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ClusterRendererModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ContentLoadModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ContentLoadModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ContentLoadModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.CoreModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.CrashReportingModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.CrashReportingModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.CrashReportingModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.DirectorModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.DirectorModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.DirectorModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.DSPGraphModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.DSPGraphModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.DSPGraphModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.GameCenterModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.GameCenterModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.GameCenterModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.GIModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.GIModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.GIModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.GridModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.GridModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.GridModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.HotReloadModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.HotReloadModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.HotReloadModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ImageConversionModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.IMGUIModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.InputLegacyModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.InputModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.InputModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.InputModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.JSONSerializeModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.JSONSerializeModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.JSONSerializeModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.LocalizationModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.LocalizationModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.LocalizationModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.NVIDIAModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.NVIDIAModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.NVIDIAModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ParticleSystemModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.PerformanceReportingModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.PerformanceReportingModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.PerformanceReportingModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.Physics2DModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.Physics2DModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.Physics2DModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.PhysicsModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ProfilerModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ProfilerModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ProfilerModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.PropertiesModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.PropertiesModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.PropertiesModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ScreenCaptureModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ScreenCaptureModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ScreenCaptureModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.SharedInternalsModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SharedInternalsModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SharedInternalsModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.SpriteMaskModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SpriteMaskModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SpriteMaskModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.SpriteShapeModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SpriteShapeModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SpriteShapeModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.StreamingModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.StreamingModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.StreamingModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.SubstanceModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SubstanceModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SubstanceModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.SubsystemsModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SubsystemsModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SubsystemsModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.TerrainModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TerrainModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TerrainModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.TerrainPhysicsModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TerrainPhysicsModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TerrainPhysicsModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.TextCoreFontEngineModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TextCoreFontEngineModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TextCoreFontEngineModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.TextCoreTextEngineModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TextCoreTextEngineModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TextCoreTextEngineModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.TextRenderingModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.TilemapModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TilemapModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TilemapModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.TLSModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TLSModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TLSModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UI">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UI.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UI.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UIElementsModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UIModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UIModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UmbraModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UmbraModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UmbraModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityAnalyticsCommonModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityAnalyticsCommonModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityAnalyticsCommonModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityAnalyticsModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityAnalyticsModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityAnalyticsModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityConnectModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityConnectModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityConnectModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityCurlModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityCurlModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityCurlModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityTestProtocolModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityTestProtocolModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityTestProtocolModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityWebRequestAssetBundleModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityWebRequestAudioModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityWebRequestModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityWebRequestTextureModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityWebRequestWWWModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.VehiclesModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VehiclesModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VehiclesModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.VFXModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VFXModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VFXModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.VideoModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VideoModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VideoModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.VirtualTexturingModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VirtualTexturingModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VirtualTexturingModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.VRModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VRModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VRModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.WindModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.WindModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.WindModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.XRModule">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.XRModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.XRModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="websocket-sharp">
-        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\websocket-sharp.dll</HintPath>
+        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\websocket-sharp.dll</HintPath>
       <Private>false</Private></Reference>
   </ItemGroup>
 

--- a/SyncUpgrades.csproj
+++ b/SyncUpgrades.csproj
@@ -7,361 +7,374 @@
         <IncludeCopyLocalFilesOutputGroup>false</IncludeCopyLocalFilesOutputGroup>
         <Configurations>Debug;Release;</Configurations>
         <Platforms>AnyCPU</Platforms>
-        <Version>2.2.6</Version>
+        <Version>3.0.0</Version>
+		<EnableGameReferences>true</EnableGameReferences>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <RestoreAdditionalProjectSources>
+      https://api.nuget.org/v3/index.json;
+      https://nuget.bepinex.dev/v3/index.json;
+      https://nuget.windows10ce.com/nuget/v3/index.json
+    </RestoreAdditionalProjectSources>
   </PropertyGroup>
 
   <ItemGroup>
       <Reference Include="Assembly-CSharp">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Assembly-CSharp.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>false</Private></Reference>
+      <Reference Include="Assembly-CSharp-firstpass">
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      </Reference>
       <Reference Include="Autodesk.Fbx">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Autodesk.Fbx.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Autodesk.Fbx.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Facepunch.Steamworks.Win64">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Facepunch.Steamworks.Win64.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Facepunch.Steamworks.Win64.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="FbxBuildTestAssets">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\FbxBuildTestAssets.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\FbxBuildTestAssets.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="mscorlib">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\mscorlib.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\mscorlib.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Newtonsoft.Json">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Newtonsoft.Json.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Newtonsoft.Json.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Photon3Unity3D">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Photon3Unity3D.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Photon3Unity3D.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="PhotonChat">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\PhotonChat.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\PhotonChat.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="PhotonRealtime">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\PhotonRealtime.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\PhotonRealtime.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="PhotonUnityNetworking">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\PhotonUnityNetworking.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\PhotonUnityNetworking.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="PhotonUnityNetworking.Utilities">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\PhotonUnityNetworking.Utilities.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\PhotonUnityNetworking.Utilities.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="PhotonVoice">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\PhotonVoice.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\PhotonVoice.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="PhotonVoice.API">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\PhotonVoice.API.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\PhotonVoice.API.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="PhotonVoice.PUN">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\PhotonVoice.PUN.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\PhotonVoice.PUN.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="REPOLib">
-        <HintPath>..\..\..\.config\r2modmanPlus-local\REPO\profiles\Default\BepInEx\plugins\Zehs-REPOLib\REPOLib.dll</HintPath>
+        <HintPath>..\..\..\AppData\Roaming\r2modmanPlus-local\REPO\profiles\Dev\BepInEx\plugins\Zehs-REPOLib\REPOLib.dll</HintPath>
       </Reference>
       <Reference Include="Sirenix.OdinInspector.Attributes">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Sirenix.OdinInspector.Attributes.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Sirenix.OdinInspector.Attributes.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Sirenix.Serialization">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Sirenix.Serialization.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Sirenix.Serialization.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Sirenix.Serialization.Config">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Sirenix.Serialization.Config.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Sirenix.Serialization.Config.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Sirenix.Utilities">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Sirenix.Utilities.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Sirenix.Utilities.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.ComponentModel.Composition">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.ComponentModel.Composition.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.ComponentModel.Composition.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Core">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Core.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Core.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Data">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Data.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Data.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Drawing">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Drawing.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Drawing.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.IO.Compression">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.IO.Compression.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.IO.Compression.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.IO.Compression.FileSystem">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.IO.Compression.FileSystem.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.IO.Compression.FileSystem.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Net.Http">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Net.Http.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Net.Http.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Numerics">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Numerics.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Numerics.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Runtime.Serialization">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Runtime.Serialization.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Runtime.Serialization.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Transactions">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Transactions.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Transactions.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Xml">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Xml.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Xml.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="System.Xml.Linq">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\System.Xml.Linq.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\System.Xml.Linq.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.AI.Navigation">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.AI.Navigation.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.AI.Navigation.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.Formats.Fbx.Runtime">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.Formats.Fbx.Runtime.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.Formats.Fbx.Runtime.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.InputSystem">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.InputSystem.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.InputSystem.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.InputSystem.ForUI">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.InputSystem.ForUI.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.InputSystem.ForUI.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.Postprocessing.Runtime">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.Postprocessing.Runtime.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.Postprocessing.Runtime.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.RenderPipelines.Core.Runtime">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.RenderPipelines.Core.Runtime.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.RenderPipelines.Core.Runtime.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.RenderPipelines.Core.ShaderLibrary">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.RenderPipelines.Core.ShaderLibrary.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.RenderPipelines.Core.ShaderLibrary.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.RenderPipelines.ShaderGraph.ShaderGraphLibrary">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.RenderPipelines.ShaderGraph.ShaderGraphLibrary.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.RenderPipelines.ShaderGraph.ShaderGraphLibrary.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.TextMeshPro">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.TextMeshPro.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.Timeline">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.Timeline.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.Timeline.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.VisualScripting.Antlr3.Runtime">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.Antlr3.Runtime.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.Antlr3.Runtime.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.VisualScripting.Core">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.Core.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.Core.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.VisualScripting.Flow">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.Flow.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.Flow.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="Unity.VisualScripting.State">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.State.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\Unity.VisualScripting.State.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.AccessibilityModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AccessibilityModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AccessibilityModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.AIModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AIModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AIModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.AndroidJNIModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AndroidJNIModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AndroidJNIModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.AnimationModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ARModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ARModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ARModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.AssetBundleModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.AudioModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ClothModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ClothModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ClothModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ClusterInputModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ClusterInputModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ClusterInputModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ClusterRendererModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ClusterRendererModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ClusterRendererModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ContentLoadModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ContentLoadModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ContentLoadModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.CoreModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.CrashReportingModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.CrashReportingModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.CrashReportingModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.DirectorModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.DirectorModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.DirectorModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.DSPGraphModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.DSPGraphModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.DSPGraphModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.GameCenterModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.GameCenterModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.GameCenterModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.GIModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.GIModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.GIModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.GridModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.GridModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.GridModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.HotReloadModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.HotReloadModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.HotReloadModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ImageConversionModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.IMGUIModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.InputLegacyModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.InputModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.InputModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.InputModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.JSONSerializeModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.JSONSerializeModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.JSONSerializeModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.LocalizationModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.LocalizationModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.LocalizationModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.NVIDIAModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.NVIDIAModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.NVIDIAModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ParticleSystemModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.PerformanceReportingModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.PerformanceReportingModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.PerformanceReportingModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.Physics2DModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.Physics2DModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.Physics2DModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.PhysicsModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ProfilerModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ProfilerModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ProfilerModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.PropertiesModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.PropertiesModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.PropertiesModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.ScreenCaptureModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ScreenCaptureModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.ScreenCaptureModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.SharedInternalsModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SharedInternalsModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SharedInternalsModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.SpriteMaskModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SpriteMaskModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SpriteMaskModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.SpriteShapeModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SpriteShapeModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SpriteShapeModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.StreamingModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.StreamingModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.StreamingModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.SubstanceModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SubstanceModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SubstanceModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.SubsystemsModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SubsystemsModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.SubsystemsModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.TerrainModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TerrainModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TerrainModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.TerrainPhysicsModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TerrainPhysicsModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TerrainPhysicsModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.TextCoreFontEngineModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TextCoreFontEngineModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TextCoreFontEngineModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.TextCoreTextEngineModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TextCoreTextEngineModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TextCoreTextEngineModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.TextRenderingModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.TilemapModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TilemapModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TilemapModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.TLSModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TLSModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.TLSModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UI">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UI.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UI.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UIElementsModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UIModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UIModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UmbraModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UmbraModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UmbraModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityAnalyticsCommonModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityAnalyticsCommonModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityAnalyticsCommonModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityAnalyticsModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityAnalyticsModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityAnalyticsModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityConnectModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityConnectModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityConnectModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityCurlModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityCurlModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityCurlModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityTestProtocolModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityTestProtocolModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityTestProtocolModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityWebRequestAssetBundleModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityWebRequestAudioModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityWebRequestModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityWebRequestTextureModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.UnityWebRequestWWWModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.VehiclesModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VehiclesModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VehiclesModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.VFXModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VFXModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VFXModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.VideoModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VideoModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VideoModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.VirtualTexturingModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VirtualTexturingModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VirtualTexturingModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.VRModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VRModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.VRModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.WindModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.WindModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.WindModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="UnityEngine.XRModule">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.XRModule.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\UnityEngine.XRModule.dll</HintPath>
       <Private>false</Private></Reference>
       <Reference Include="websocket-sharp">
-        <HintPath>..\..\..\..\..\mnt\2TB_NVME\SteamLibrary\steamapps\common\REPO\REPO_Data\Managed\websocket-sharp.dll</HintPath>
+        <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\REPO\REPO_Data\Managed\websocket-sharp.dll</HintPath>
       <Private>false</Private></Reference>
   </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="BepInEx.Core" Version="5.4.21"/>
+        <PackageReference Include="BepInEx.Core" Version="5.4.21" />
+		<PackageReference Include="Linkoid.Repo.Plugin.Build" Version="*" PrivateAssets="all" />
     </ItemGroup>
 </Project>

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "SyncUpgrades",
-  "version_number": "2.2.6",
+  "version_number": "3.0.0",
   "website_url": "https://github.com/TGO-Inc/SyncUpgrades",
   "description": "Syncs upgrades between all players in a game. [Client -> Host -> All] or [Host -> All].",
   "dependencies": [
-    "Zehs-REPOLib-2.1.0"
+    "Zehs-REPOLib-3.0.3"
   ]
 }


### PR DESCRIPTION
Add support for R.E.P.O. 0.3.x

- Fixed wrapper calls to match new function signatures
- Added new upgrades: `TumbleClimb` and `DeathHeadBattery`
- Updated REPOLib dependency to 3.0.3